### PR TITLE
AdUnitID's and AppID's added for rewarded videos

### DIFF
--- a/Objective-C/admob/RewardedVideoExample/RewardedVideoExample/AppDelegate.m
+++ b/Objective-C/admob/RewardedVideoExample/RewardedVideoExample/AppDelegate.m
@@ -28,7 +28,7 @@
   // Use Firebase library to configure APIs
   [FIRApp configure];
   // Initialize Google Mobile Ads SDK
-  [GADMobileAds configureWithApplicationID:@"INSERT_APP_ID_HERE"];
+  [GADMobileAds configureWithApplicationID:@"ca-app-pub-3940256099942544~1458002511"];
 
   return YES;
 }

--- a/Objective-C/admob/RewardedVideoExample/RewardedVideoExample/ViewController.m
+++ b/Objective-C/admob/RewardedVideoExample/RewardedVideoExample/ViewController.m
@@ -101,7 +101,7 @@ typedef NS_ENUM(NSInteger, GameState) {
 - (void)requestRewardedVideo {
   GADRequest *request = [GADRequest request];
   [[GADRewardBasedVideoAd sharedInstance] loadRequest:request
-                                         withAdUnitID:@"INSERT_AD_UNIT_HERE"];
+                                         withAdUnitID:@"ca-app-pub-3940256099942544/1712485313"];
 }
 
 - (void)pauseGame {

--- a/Swift/admob/RewardedVideoExample/RewardedVideoExample/AppDelegate.swift
+++ b/Swift/admob/RewardedVideoExample/RewardedVideoExample/AppDelegate.swift
@@ -27,7 +27,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // Use Firebase library to configure APIs
     FIRApp.configure()
     // Initialize Google Mobile Ads SDK
-    GADMobileAds.configure(withApplicationID: "INSERT_APP_ID_HERE")
+    GADMobileAds.configure(withApplicationID: "ca-app-pub-3940256099942544~1458002511")
 
     return true
   }

--- a/Swift/admob/RewardedVideoExample/RewardedVideoExample/ViewController.swift
+++ b/Swift/admob/RewardedVideoExample/RewardedVideoExample/ViewController.swift
@@ -93,7 +93,7 @@ class ViewController: UIViewController, GADRewardBasedVideoAdDelegate, UIAlertVi
 
     if !adRequestInProgress && rewardBasedVideo?.isReady == false {
       rewardBasedVideo?.load(GADRequest(),
-          withAdUnitID: "INSERT_AD_UNIT_HERE")
+          withAdUnitID: "ca-app-pub-3940256099942544/1712485313")
       adRequestInProgress = true
     }
 


### PR DESCRIPTION
Examples for RewardedVideos would not work due to invalid settings and
missing app and ad unit ID's.
Recieved these from support team, issuing pull request.