### PR TITLE
Fix "[!] Invalid `Podfile` file: syntax error, unexpected string literal, expecting end-of-input"

### DIFF
--- a/Swift/admob/NativeAdvancedExample/Podfile
+++ b/Swift/admob/NativeAdvancedExample/Podfile
@@ -1,6 +1,6 @@
 source 'https://github.com/CocoaPods/Specs.git'
 
-platform :ios, 9.0'
+platform :ios, '9.0'
 
 target 'NativeAdvancedExample' do
   use_frameworks!


### PR DESCRIPTION
Fixed a 5 month old syntax error living in the NativeAdvancedExample Podfile