### PR TITLE
Fix error on no rootViewController in banner example

### DIFF
--- a/Swift/advanced/SwiftUIDemo/SwiftUIDemo/Banner/BannerContentView.swift
+++ b/Swift/advanced/SwiftUIDemo/SwiftUIDemo/Banner/BannerContentView.swift
@@ -57,6 +57,13 @@ private struct BannerView: UIViewRepresentable {
 
     private(set) lazy var bannerView: GADBannerView = {
       let banner = GADBannerView(adSize: parent.adSize)
+
+      // Set banner's rootViewcontroller
+      let scenes = UIApplication.shared.connectedScenes
+      let windowScene = scenes.first as? UIWindowScene
+      let window = windowScene?.windows.first
+      banner.rootViewController = window?.rootViewController
+      
       // [START load_ad]
       banner.adUnitID = "ca-app-pub-3940256099942544/2435281174"
       banner.load(GADRequest())


### PR DESCRIPTION
Fixing the on the error of no rootViewController in Banner example.
The error message:
`
FAILED TO RECEIVE AD: You must set the rootViewController property of <GADInternalBannerView: 0x107c20dd0; frame = (0 0; 393 61); clipsToBounds = YES; hidden = YES; autoresize = W+H; backgroundColor = UIExtendedGrayColorSpace 0 0; layer = <CALayer: 0x600000327040>> before loading a request.
`